### PR TITLE
fix/InterviwerVisbility -- Hides Interviewers names in Applicant view only 

### DIFF
--- a/src/components/Timeslots/ApplicantView.js
+++ b/src/components/Timeslots/ApplicantView.js
@@ -292,7 +292,8 @@ class ApplicantView extends Component {
               <Card.Body>
                 <Card.Title>{formatTime(slot.time)}</Card.Title>
                 <Card.Subtitle className="mb-2 text-muted">
-                  {Object.values(slot.interviewers).join(", ")}
+                  Number of interviewers:{" "}
+                  {Object.values(slot.interviewers).length}
                 </Card.Subtitle>
                 <Card.Subtitle className="mb-2 text-muted">
                   {slot.timeslotLength} mins


### PR DESCRIPTION
Current applicant view when picking interview time slots: 
![Screen Shot 2021-04-13 at 8 21 33 PM](https://user-images.githubusercontent.com/40352345/114636911-25509e80-9c96-11eb-854e-d32ff293120e.png)

But this is not ideal since we do not want the applicants to be able to pick specific people, so we do not want to display this information. So, here is the modified and updated view: 

![Screen Shot 2021-04-13 at 8 22 18 PM](https://user-images.githubusercontent.com/40352345/114637004-59c45a80-9c96-11eb-8cb7-4711b19729e7.png)

I have chosen to instead display the number of interviewers in this time slot since this is more appropriate information. This change was made in the TimeSlotCard so this change is applicable anywhere this card is displayed on the applicant view (applicant.js).